### PR TITLE
Fix AV1 decoding crash on iOS

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,5 +41,5 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation "org.videolan.android:libvlc-all:3.6.2"
+    implementation "org.videolan.android:libvlc-all:3.6.3"
 }

--- a/ios/ExpoLibVlcPlayer.podspec
+++ b/ios/ExpoLibVlcPlayer.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'MobileVLCKit', '3.6.0'
+  s.dependency 'MobileVLCKit', '3.6.1b1'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {


### PR DESCRIPTION
This PR bumps `MobileVLCKit` version to `3.6.1b1` to fix a crash while playing specific video files.

It also bumps `libvlcjni` version to `3.6.3` given that it's the latest 3.x version available.

The latter helps keep both bindings on the same major release.

—

Closes https://github.com/cornejobarraza/expo-libvlc-player/issues/7