### PR TITLE
Fix: style props not applied to wrapper View

### DIFF
--- a/src/LibVlcPlayerView.tsx
+++ b/src/LibVlcPlayerView.tsx
@@ -111,7 +111,7 @@ const LibVlcPlayerView = forwardRef<LibVlcPlayerViewRef, LibVlcPlayerViewProps>(
   const nativeRatio = convertAspectRatio(aspectRatio);
 
   return (
-    <View style={{ aspectRatio: nativeRatio }}>
+    <View style={[props.style, { aspectRatio: nativeRatio }]}>
       <NativeView
         {...props}
         ref={ref}


### PR DESCRIPTION
## Problem

  When using flex-based layouts to size `LibVlcPlayerView` (e.g. `style={{ flex: 1 }}` for a full-screen player), the video surface renders with zero height. Audio plays normally but no video is visible.

  ## Root Cause

  In `src/LibVlcPlayerView.tsx`, the component wraps `NativeView` in a `<View>` for aspect ratio handling:

      // before
      <View style={{ aspectRatio: nativeRatio }}>
        <NativeView {...props} ref={ref} style={[props.style, { height: "100%" }]} ... />
      </View>

  `props.style` is applied to the inner `NativeView`, but the outer wrapper `View` receives no layout styles. When a consumer passes `style={{ flex: 1 }}`, the wrapper has no size constraint
   and collapses to zero height. The `NativeView`'s `height: "100%"` resolves to 100% of zero.

  ### Why the example app is not affected

  The example app uses `aspectRatio="auto"` with a static style (`backgroundColor` + `borderRadius`) and no flex-based sizing. The wrapper computes its height from the aspect ratio +
  available width, so it works fine. But any layout using `flex: 1` (the standard approach for full-screen players) will break.

  ## Fix

  Move `props.style` to the wrapper `View` so it receives layout properties, and have the `NativeView` fill its parent:

      // after
      <View style={[props.style, { aspectRatio: nativeRatio }]}>
        <NativeView {...props} ref={ref} style={{ width: "100%", height: "100%" }} ... />
      </View>

  This is a 2-line change. The `aspectRatio` prop still works as before when explicitly set. The existing example app behavior is unchanged.