### PR TITLE
Add destroy() method for explicit VLC player teardown

### DIFF
--- a/ios/LibVlcPlayerModule.swift
+++ b/ios/LibVlcPlayerModule.swift
@@ -152,6 +152,10 @@ public class LibVlcPlayerModule: Module {
             AsyncFunction("stopPictureInPicture") { (view: LibVlcPlayerView) in
                 view.stopPictureInPicture()
             }
+
+            AsyncFunction("destroy") { (view: LibVlcPlayerView) in
+                view.destroyPlayer()
+            }
         }
     }
 }

--- a/ios/LibVlcPlayerView.swift
+++ b/ios/LibVlcPlayerView.swift
@@ -109,6 +109,7 @@ class LibVlcPlayerView: ExpoView {
     }
 
     func destroyPlayer() {
+        mediaPlayer?.delegate = nil
         mediaPlayer?.stop()
         mediaPlayer = nil
         vlcDialog?.customRenderer = nil

--- a/src/LibVlcPlayer.types.ts
+++ b/src/LibVlcPlayer.types.ts
@@ -23,6 +23,12 @@ export interface LibVlcPlayerViewRef {
    */
   readonly stop: () => Promise<void>;
   /**
+   * Destroys the player and releases all resources
+   *
+   * @returns A promise which resolves to `void`
+   */
+  readonly destroy: () => Promise<void>;
+  /**
    * Sets the time or position of the current player
    *
    * @param value - Must be a number equal or greater than `0`


### PR DESCRIPTION
## Summary

- Expose a new `destroy()` method on the player ref, allowing explicit teardown of the VLC player and release of all associated resources from JS
- Nil out the media player delegate before stopping in `destroyPlayer()` to prevent potential delegate callbacks firing during or after teardown

## Changes

- **`ios/LibVlcPlayerModule.swift`** — Register `destroy` as an async function on the native view module
- **`ios/LibVlcPlayerView.swift`** — Set `mediaPlayer?.delegate = nil` before `stop()` in `destroyPlayer()` to avoid race conditions with delegate callbacks
- **`src/LibVlcPlayer.types.ts`** — Add `destroy()` to the `LibVlcPlayerViewRef` type with JSDoc