### PR TITLE
Fix audio and subtitle track ids on iOS

### DIFF
--- a/ios/LibVlcPlayerView.swift
+++ b/ios/LibVlcPlayerView.swift
@@ -235,29 +235,21 @@ class LibVlcPlayerView: ExpoView {
     }
 
     func getMediaTracks() -> MediaTracks {
-        var mediaTracks = MediaTracks()
+        guard let player = mediaPlayer else { return MediaTracks() }
 
-        if let player = mediaPlayer {
-            let audioTracks: [Track] = player.audioTracks.enumerated().map { index, audio in
-                return Track(id: index, name: audio.trackName)
-            }
+        let audioTracks = player.audioTracks.enumerated()
+        let videoTracks = player.videoTracks.enumerated()
+        let subtitleTracks = player.textTracks.enumerated()
 
-            let videoTracks: [Track] = player.videoTracks.enumerated().map { index, video in
-                return Track(id: index, name: video.trackName)
-            }
+        let audio = audioTracks.map { index, audio in Track(id: index, name: audio.trackName) }
+        let video = videoTracks.map { index, video in Track(id: index, name: video.trackName) }
+        let subtitle = subtitleTracks.map { index, subtitle in Track(id: index, name: subtitle.trackName) }
 
-            let subtitleTracks: [Track] = player.textTracks.enumerated().map { index, subtitle in
-                return Track(id: index, name: subtitle.trackName)
-            }
-
-            mediaTracks = MediaTracks(
-                audio: audioTracks,
-                video: videoTracks,
-                subtitle: subtitleTracks
-            )
-        }
-
-        return mediaTracks
+        return MediaTracks(
+            audio: audio,
+            video: video,
+            subtitle: subtitle
+        )
     }
 
     func getMediaLength() -> Int {

--- a/ios/LibVlcPlayerView.swift
+++ b/ios/LibVlcPlayerView.swift
@@ -238,22 +238,16 @@ class LibVlcPlayerView: ExpoView {
         var mediaTracks = MediaTracks()
 
         if let player = mediaPlayer {
-            let audioTracks: [Track] = player.audioTracks.map { audio in
-                let id = (audio.trackId as NSString).intValue
-                let name = audio.trackName
-                return Track(id: Int(id), name: name)
+            let audioTracks: [Track] = player.audioTracks.enumerated().map { index, audio in
+                return Track(id: index, name: audio.trackName)
             }
 
-            let videoTracks: [Track] = player.videoTracks.map { video in
-                let id = (video.trackId as NSString).intValue
-                let name = video.trackName
-                return Track(id: Int(id), name: name)
+            let videoTracks: [Track] = player.videoTracks.enumerated().map { index, video in
+                return Track(id: index, name: video.trackName)
             }
 
-            let subtitleTracks: [Track] = player.textTracks.map { subtitle in
-                let id = (subtitle.trackId as NSString).intValue
-                let name = subtitle.trackName
-                return Track(id: Int(id), name: name)
+            let subtitleTracks: [Track] = player.textTracks.enumerated().map { index, subtitle in
+                return Track(id: index, name: subtitle.trackName)
             }
 
             mediaTracks = MediaTracks(


### PR DESCRIPTION
## Problem

On iOS, only one audio track and one subtitle track are ever listed, even when
the media has several. It's most visible on a multi-track local file: desktop
VLC lists every track, the player lists one.

## Root Cause

`getMediaTracks()` builds each track id from `(track.trackId as NSString).intValue`:

```swift
let audioTracks: [Track] = player.audioTracks.map { audio in
    let id = (audio.trackId as NSString).intValue
    ...
}
```

In VLCKit 4, `VLCMediaPlayerTrack.trackId` is a **string** (`"audio/0"`,
`"audio/1"`, `"spu/0"`, …), so `.intValue` returns `0` for every track (no
leading digit). Every track ends up with `id = 0`, so any consumer keying tracks
by id — e.g. de-duplicating the incremental `onESAdded` events — collapses them
into a single track.

Android is unaffected (it returns real libvlc track ids).

## Fix

Selection is already index-based: `selectTrackAtIndex:type:` is documented as
*"index: position of the track in the list"* (it indexes into `audioTracks` /
`videoTracks` / `textTracks`). So expose the array index as the track id, which
keeps enumeration and selection consistent and gives each track a unique id:

```swift
let audioTracks: [Track] = player.audioTracks.enumerated().map { index, audio in
    return Track(id: index, name: audio.trackName)
}
```

`-1` (deselect) is untouched; indices are always `>= 0`. No behavior change for
single-track media.